### PR TITLE
More data cleaner logging

### DIFF
--- a/src/main/java/org/radarbase/output/cleaner/TimestampExtractionCheck.kt
+++ b/src/main/java/org/radarbase/output/cleaner/TimestampExtractionCheck.kt
@@ -55,19 +55,10 @@ class TimestampExtractionCheck(
 
             try {
                 when (cacheStore.contains(path, record)) {
-                    TimestampFileCacheStore.FindResult.FILE_NOT_FOUND -> {
-                        logger.warn("Target {} for {} has not been created yet.", path, record)
-                        return false
-                    }
-                    TimestampFileCacheStore.FindResult.NOT_FOUND -> {
-                        logger.warn("Target {} does not contain record {}", path, record)
-                        return false
-                    }
+                    TimestampFileCacheStore.FindResult.FILE_NOT_FOUND -> return false
+                    TimestampFileCacheStore.FindResult.NOT_FOUND -> return false
                     TimestampFileCacheStore.FindResult.FOUND -> return true
-                    TimestampFileCacheStore.FindResult.BAD_SCHEMA -> {
-                        logger.warn("Schema of {} does not match schema of record {}", path, record)
-                        suffix += 1
-                    }  // continue next suffix
+                    TimestampFileCacheStore.FindResult.BAD_SCHEMA -> suffix += 1  // continue next suffix
                 }
             } catch (ex: IOException) {
                 logger.error("Failed to read target file {} for checking data integrity", path, ex)

--- a/src/main/java/org/radarbase/output/cleaner/TimestampExtractionCheck.kt
+++ b/src/main/java/org/radarbase/output/cleaner/TimestampExtractionCheck.kt
@@ -55,13 +55,22 @@ class TimestampExtractionCheck(
 
             try {
                 when (cacheStore.contains(path, record)) {
-                    TimestampFileCacheStore.FindResult.FILE_NOT_FOUND -> return false
-                    TimestampFileCacheStore.FindResult.NOT_FOUND -> return false
+                    TimestampFileCacheStore.FindResult.FILE_NOT_FOUND -> {
+                        logger.warn("Target {} for {} has not been created yet.", path, record)
+                        return false
+                    }
+                    TimestampFileCacheStore.FindResult.NOT_FOUND -> {
+                        logger.warn("Target {} does not contain record {}", path, record)
+                        return false
+                    }
                     TimestampFileCacheStore.FindResult.FOUND -> return true
-                    TimestampFileCacheStore.FindResult.BAD_SCHEMA -> suffix += 1  // continue next suffix
+                    TimestampFileCacheStore.FindResult.BAD_SCHEMA -> {
+                        logger.warn("Schema of {} does not match schema of record {}", path, record)
+                        suffix += 1
+                    }  // continue next suffix
                 }
             } catch (ex: IOException) {
-                logger.error("Failed to read target file for checking data integrity", ex)
+                logger.error("Failed to read target file {} for checking data integrity", path, ex)
                 return false
             }
         } while (true)

--- a/src/main/java/org/radarbase/output/cleaner/TimestampFileCache.kt
+++ b/src/main/java/org/radarbase/output/cleaner/TimestampFileCache.kt
@@ -53,7 +53,9 @@ class TimestampFileCache(
         if (header != null) {
             val recordHeader = converterFactory.headerFor(record)
             if (!recordHeader.contentEquals(header)) {
-                throw IllegalArgumentException("Header mismatch")
+                throw IllegalArgumentException(
+                        "Header mismatch: record header ${recordHeader.contentToString()}" +
+                                " does not match target header ${header.contentToString()}")
             }
         }
 

--- a/src/test/java/org/radarbase/output/cleaner/TimestampFileCacheTest.kt
+++ b/src/test/java/org/radarbase/output/cleaner/TimestampFileCacheTest.kt
@@ -1,0 +1,108 @@
+package org.radarbase.output.cleaner
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericData
+import org.apache.avro.generic.GenericRecord
+import org.apache.avro.generic.GenericRecordBuilder
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import org.radarbase.output.FileStoreFactory
+import org.radarbase.output.compression.IdentityCompression
+import org.radarbase.output.config.LocalConfig
+import org.radarbase.output.format.CsvAvroConverterFactory
+import org.radarbase.output.target.LocalTargetStorage
+import java.io.ByteArrayInputStream
+import java.io.FileNotFoundException
+import java.io.InputStreamReader
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal class TimestampFileCacheTest {
+    private lateinit var record: GenericData.Record
+    private var now: Double = 0.0
+    private lateinit var schema: Schema
+    private lateinit var factory: FileStoreFactory
+    private lateinit var csvConverter: CsvAvroConverterFactory
+
+    @BeforeEach
+    fun setUp() {
+        csvConverter = CsvAvroConverterFactory()
+        factory = mock {
+            on { recordConverter } doReturn csvConverter
+            on { targetStorage } doReturn LocalTargetStorage(LocalConfig())
+            on { compression } doReturn IdentityCompression()
+        }
+        schema = Schema.Parser().parse(javaClass.getResourceAsStream("android_phone_light.avsc"))
+        now = System.currentTimeMillis() / 1000.0
+        record = GenericRecordBuilder(schema)
+                .set("key", GenericRecordBuilder(schema.getField("key")!!.schema())
+                        .set("projectId", "p")
+                        .set("userId", "u")
+                        .set("sourceId", "s")
+                        .build())
+                .set("value", GenericRecordBuilder(schema.getField("value")!!.schema())
+                        .set("time", now)
+                        .set("timeReceived", now + 1.0)
+                        .set("light", 1.0f)
+                        .build())
+                .build()
+    }
+
+    @Test
+    fun testFileCacheFound(@TempDir path: Path) {
+        val targetPath = path.resolve("test.avro")
+        writeRecord(targetPath, record)
+        val timestampFileCache = TimestampFileCache(factory, targetPath)
+        assertThat(timestampFileCache.contains(record), `is`(true))
+    }
+
+    private fun writeRecord(path: Path, record: GenericRecord) {
+        Files.newBufferedWriter(path).use { wr ->
+            ByteArrayInputStream(ByteArray(0)).use { emptyInput ->
+                InputStreamReader(emptyInput).use { emptyReader ->
+                    csvConverter.converterFor(wr, record, true, emptyReader).use { converter ->
+                        converter.writeRecord(record)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testFileCacheNotFound(@TempDir path: Path) {
+        val targetPath = path.resolve("test.avro")
+        assertThrows<FileNotFoundException> { TimestampFileCache(factory, targetPath) }
+    }
+
+    @Test
+    fun testHeaderMismatch(@TempDir path: Path) {
+        val targetPath = path.resolve("test.avro")
+        Files.newBufferedWriter(targetPath).use { writer ->
+            writer.write("key.projectId,key.userId,key.sourceId,value.time,value.timeReceived,value.luminance")
+        }
+        val cache = TimestampFileCache(factory, targetPath)
+        assertThrows<IllegalArgumentException> { cache.contains(record) }
+    }
+
+    @Test
+    fun testNotFound(@TempDir path: Path) {
+        val targetPath = path.resolve("test.avro")
+
+        val otherRecord = GenericRecordBuilder(record)
+                .set("value", GenericRecordBuilder(record.get("value") as GenericData.Record)
+                        .set("time", now + 1.0)
+                        .set("timeReceived", now + 2.0)
+                        .build())
+                .build()
+
+        writeRecord(targetPath, otherRecord)
+        val cache = TimestampFileCache(factory, targetPath)
+        assertThat(cache.contains(record), `is`(false))
+    }
+}

--- a/src/test/resources/org/radarbase/output/cleaner/android_phone_light.avsc
+++ b/src/test/resources/org/radarbase/output/cleaner/android_phone_light.avsc
@@ -1,0 +1,94 @@
+{
+  "type" : "record",
+  "name" : "PhoneLight",
+  "namespace" : "org.radarcns.kafka.ObservationKey_org.radarcns.passive.phone",
+  "doc" : "combined key-value record",
+  "fields" : [ {
+    "name" : "key",
+    "type" : {
+      "type" : "record",
+      "name" : "ObservationKey",
+      "namespace" : "org.radarcns.kafka",
+      "doc" : "Key of an observation.",
+      "fields" : [ {
+        "name" : "projectId",
+        "type" : [ "null", {
+          "type" : "string",
+          "connect.doc" : "Project identifier. Null if unknown or the user is not enrolled in a project.",
+          "connect.parameters" : {
+            "avro.java.string" : "String"
+          },
+          "avro.java.string" : "String"
+        } ],
+        "doc" : "Project identifier. Null if unknown or the user is not enrolled in a project.",
+        "default" : null
+      }, {
+        "name" : "userId",
+        "type" : {
+          "type" : "string",
+          "connect.doc" : "User Identifier created during the enrolment.",
+          "connect.parameters" : {
+            "avro.java.string" : "String"
+          },
+          "avro.java.string" : "String"
+        },
+        "doc" : "User Identifier created during the enrolment."
+      }, {
+        "name" : "sourceId",
+        "type" : {
+          "type" : "string",
+          "connect.doc" : "Unique identifier associated with the source.",
+          "connect.parameters" : {
+            "avro.java.string" : "String"
+          },
+          "avro.java.string" : "String"
+        },
+        "doc" : "Unique identifier associated with the source."
+      } ],
+      "connect.doc" : "Key of an observation.",
+      "connect.version" : 1,
+      "connect.parameters" : {
+        "connect.record.doc" : "Key of an observation."
+      },
+      "connect.name" : "org.radarcns.kafka.ObservationKey"
+    },
+    "doc" : "Key of a Kafka SinkRecord"
+  }, {
+    "name" : "value",
+    "type" : {
+      "type" : "record",
+      "name" : "PhoneLight",
+      "namespace" : "org.radarcns.passive.phone",
+      "doc" : "Data from the light sensor in luminous flux per unit area.",
+      "fields" : [ {
+        "name" : "time",
+        "type" : {
+          "type" : "double",
+          "connect.doc" : "Device timestamp in UTC (s)."
+        },
+        "doc" : "Device timestamp in UTC (s)."
+      }, {
+        "name" : "timeReceived",
+        "type" : {
+          "type" : "double",
+          "connect.doc" : "Device receiver timestamp in UTC (s)."
+        },
+        "doc" : "Device receiver timestamp in UTC (s)."
+      }, {
+        "name" : "light",
+        "type" : {
+          "type" : "float",
+          "connect.doc" : "Illuminance (lx)."
+        },
+        "doc" : "Illuminance (lx)."
+      } ],
+      "connect.doc" : "Data from the light sensor in luminous flux per unit area.",
+      "connect.version" : 1,
+      "connect.parameters" : {
+        "connect.record.doc" : "Data from the light sensor in luminous flux per unit area."
+      },
+      "connect.name" : "org.radarcns.passive.phone.PhoneLight"
+    },
+    "doc" : "Value of a Kafka SinkRecord"
+  } ]
+}


### PR DESCRIPTION
- More verbose warning messages on record mismatches.
- Tested the `TimestampFileCache`.

Edit: this PR is tracked by docker image `radarbase/radar-output-restructure:1.1.1-logging`