### PR TITLE
Only process files if they are a minimum age.

### DIFF
--- a/restructure.yml
+++ b/restructure.yml
@@ -79,6 +79,10 @@ worker:
   numThreads: 2
   # Maximum number of files to process in any given topic.
   maxFilesPerTopic: null
+  # Minimum time in seconds since a source file was last modified before it is
+  # considered for processing. This avoids synchronization issues when a file has just been
+  # written.
+  minimumFileAge: 60
 
 cleaner:
   # Enable cleaning up old source files

--- a/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
+++ b/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
@@ -4,10 +4,7 @@ import io.minio.PutObjectOptions
 import io.minio.PutObjectOptions.MAX_PART_SIZE
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.radarbase.output.config.PathConfig
-import org.radarbase.output.config.ResourceConfig
-import org.radarbase.output.config.RestructureConfig
-import org.radarbase.output.config.S3Config
+import org.radarbase.output.config.*
 import org.radarbase.output.util.Timer
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Paths
@@ -29,7 +26,8 @@ class RestructureS3IntegrationTest {
         val config = RestructureConfig(
                 source = ResourceConfig("s3", s3 = sourceConfig),
                 target = ResourceConfig("s3", s3 = targetConfig),
-                paths = PathConfig(inputs = listOf(Paths.get("in")))
+                paths = PathConfig(inputs = listOf(Paths.get("in"))),
+                worker = WorkerConfig(minimumFileAge = 0L)
         )
         val application = Application(config)
         val sourceClient = sourceConfig.createS3Client()

--- a/src/main/java/org/radarbase/output/Application.kt
+++ b/src/main/java/org/radarbase/output/Application.kt
@@ -32,6 +32,7 @@ import org.radarbase.output.util.ProgressBar.Companion.format
 import org.radarbase.output.util.Timer
 import org.radarbase.output.worker.FileCacheStore
 import org.radarbase.output.cleaner.SourceDataCleaner
+import org.radarbase.output.util.TimeUtil.durationSince
 import org.radarbase.output.worker.RadarKafkaRestructure
 import org.slf4j.LoggerFactory
 import redis.clients.jedis.JedisPool
@@ -186,8 +187,6 @@ class Application(
     companion object {
         private val logger = LoggerFactory.getLogger(Application::class.java)
         const val CACHE_SIZE_DEFAULT = 100
-
-        private fun Temporal.durationSince() = Duration.between(this, Instant.now())
 
         private fun parseArgs(args: Array<String>): CommandLineArgs {
             val commandLineArgs = CommandLineArgs()

--- a/src/main/java/org/radarbase/output/config/RestructureConfig.kt
+++ b/src/main/java/org/radarbase/output/config/RestructureConfig.kt
@@ -143,7 +143,14 @@ data class WorkerConfig(
          * Number of offsets to simultaneously keep in cache. A higher size will
          * decrease overhead but increase memory usage.
          */
-        val cacheOffsetsSize: Long = 500_000) {
+        val cacheOffsetsSize: Long = 500_000,
+        /**
+         * Minimum time since the file was last modified in seconds. Avoids
+         * synchronization issues that may occur in a source file that is being
+         * appended to.
+         */
+        val minimumFileAge: Long = 60
+) {
     init {
         check(cacheSize >= 1) { "Maximum files per topic must be strictly positive" }
         maxFilesPerTopic?.let { check(it >= 1) { "Maximum files per topic must be strictly positive" } }

--- a/src/main/java/org/radarbase/output/util/TimeUtil.kt
+++ b/src/main/java/org/radarbase/output/util/TimeUtil.kt
@@ -4,11 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 import java.math.RoundingMode
-import java.time.Instant
-import java.time.LocalDate
-import java.time.LocalDateTime
-import java.time.ZoneOffset
+import java.time.*
 import java.time.format.DateTimeParseException
+import java.time.temporal.Temporal
 
 object TimeUtil {
     private val NANO_MULTIPLIER = 1_000_000_000.toBigDecimal()
@@ -143,4 +141,7 @@ object TimeUtil {
     fun Instant.toDouble() = (epochSecond.toBigDecimal()
             + (nano.toBigDecimal().divide(NANO_MULTIPLIER, 9, RoundingMode.HALF_UP))
             ).toDouble()
+
+
+    fun Temporal.durationSince(): Duration = Duration.between(this, Instant.now())
 }


### PR DESCRIPTION
Adds `worker.minimumFileAge` configuration property. A restructure worker will only consider a file for processing if it has not been modified for that number of seconds. This avoids synchronisation issues when a file is still being written or appended to when the restructure script is called.