### PR TITLE
Release 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ When upgrading to version 0.6.0 from version 0.5.x or earlier, please follow the
 
 This package is available as docker image [`radarbase/radar-output-restructure`](https://hub.docker.com/r/radarbase/radar-output-restructure). The entrypoint of the image is the current application. So in all the commands listed in usage, replace `radar-output-restructure` with for example:
 ```shell
-docker run --rm -t --network hadoop -v "$PWD/output:/output" radarbase/radar-output-restructure:1.1.2-hdfs -n hdfs-namenode -o /output /myTopic
+docker run --rm -t --network hadoop -v "$PWD/output:/output" radarbase/radar-output-restructure:1.1.3-hdfs -n hdfs-namenode -o /output /myTopic
 ```
 if your docker cluster is running in the `hadoop` network and your output directory should be `./output`.
 
@@ -171,7 +171,7 @@ This package requires at least Java JDK 8. Build the distribution with
 and install the package into `/usr/local` with for example
 ```shell
 sudo mkdir -p /usr/local
-sudo tar -xzf build/distributions/radar-output-restructure-1.1.2.tar.gz -C /usr/local --strip-components=1
+sudo tar -xzf build/distributions/radar-output-restructure-1.1.3.tar.gz -C /usr/local --strip-components=1
 ```
 
 Now the `radar-output-restructure` command should be available.

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ ext {
     jCommanderVersion = '1.78'
     almworksVersion = '1.1.1'
     junitVersion = '5.6.1'
-    minioVersion = '7.0.1'
+    minioVersion = '7.1.0'
     jedisVersion = '3.2.0'
     azureStorageVersion = '12.6.0'
 }
@@ -84,6 +84,11 @@ compileKotlin {
     }
 }
 compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+compileIntegrationTestKotlin {
     kotlinOptions {
         jvmTarget = "1.8"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'org.radarbase'
-version '1.1.3-SNAPSHOT'
+version '1.1.3'
 mainClassName = 'org.radarbase.output.Application'
 
 sourceCompatibility = '1.8'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'org.radarbase'
-version '1.1.2'
+version '1.1.3-SNAPSHOT'
 mainClassName = 'org.radarbase.output.Application'
 
 sourceCompatibility = '1.8'

--- a/restructure.yml
+++ b/restructure.yml
@@ -13,6 +13,9 @@ source:
     bucket: radar
     accessToken: minioadmin
     secretKey: minioadmin
+    # If true, try to read the metadata property "endOffset" to determine the
+    # final offset of an input object.
+    #endOffsetFromTags: false
   azure:
     endpoint: https://MyBlobStorageAccount.blob.core.windows.net
     # when using personal login
@@ -25,6 +28,9 @@ source:
     #sasToken: MyLongToken
     # if no credentials are supplied, this only works with a publicly writable blob storage
     container: MySourceContainer
+    # If true, try to read the metadata property "endOffset" to determine the
+    # final offset of an input object.
+    #endOffsetFromMetadata: false
   # only actually needed if source type is hdfs
   hdfs:
     nameNodes: [hdfs-namenode-1, hdfs-namenode-2]

--- a/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
+++ b/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
@@ -56,6 +56,8 @@ class RestructureS3IntegrationTest {
         val targetClient = targetConfig.createS3Client()
         val files = targetClient.listObjects(ListObjectsArgs.Builder().bucketBuild(targetConfig.bucket) {
                     prefix("output")
+                    recursive(true)
+                    useUrlEncodingType(false)
                 })
                 .map { it.get().objectName() }
                 .toList()

--- a/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
+++ b/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
@@ -54,7 +54,7 @@ class RestructureS3IntegrationTest {
                 .map { it.get().objectName() }
                 .toList()
 
-        application.redisPool.resource.use { redis ->
+        application.redisHolder.execute { redis ->
             assertEquals(1L, redis.del("offsets/application_server_status.json"))
             assertEquals(1L, redis.del("offsets/android_phone_acceleration.json"))
         }

--- a/src/integrationTest/java/org/radarbase/output/accounting/RedisRemoteLockManagerTest.kt
+++ b/src/integrationTest/java/org/radarbase/output/accounting/RedisRemoteLockManagerTest.kt
@@ -9,20 +9,20 @@ import org.junit.jupiter.api.Test
 import redis.clients.jedis.JedisPool
 
 internal class RedisRemoteLockManagerTest {
-    private lateinit var redisPool: JedisPool
+    private lateinit var redisHolder: RedisHolder
     private lateinit var lockManager1: RemoteLockManager
     private lateinit var lockManager2: RemoteLockManager
 
     @BeforeEach
     fun setUp() {
-        redisPool = JedisPool()
-        lockManager1 = RedisRemoteLockManager(redisPool, "locks")
-        lockManager2 = RedisRemoteLockManager(redisPool, "locks")
+        redisHolder = RedisHolder(JedisPool())
+        lockManager1 = RedisRemoteLockManager(redisHolder, "locks")
+        lockManager2 = RedisRemoteLockManager(redisHolder, "locks")
     }
 
     @AfterEach
     fun tearDown() {
-        redisPool.close()
+        redisHolder.close()
     }
 
     @Test

--- a/src/main/java/org/radarbase/output/Application.kt
+++ b/src/main/java/org/radarbase/output/Application.kt
@@ -65,11 +65,11 @@ class Application(
 
     override val targetStorage: TargetStorage = TargetStorageFactory(config.target).createTargetStorage()
 
-    override val redisPool: JedisPool = JedisPool(config.redis.uri)
+    override val redisHolder: RedisHolder = RedisHolder(JedisPool(config.redis.uri))
     override val remoteLockManager: RemoteLockManager = RedisRemoteLockManager(
-            redisPool, config.redis.lockPrefix)
+            redisHolder, config.redis.lockPrefix)
 
-    override val offsetPersistenceFactory: OffsetPersistenceFactory = OffsetRedisPersistence(redisPool)
+    override val offsetPersistenceFactory: OffsetPersistenceFactory = OffsetRedisPersistence(redisHolder)
 
     @Throws(IOException::class)
     override fun newFileCacheStore(accountant: Accountant) = FileCacheStore(this, accountant)

--- a/src/main/java/org/radarbase/output/FileStoreFactory.kt
+++ b/src/main/java/org/radarbase/output/FileStoreFactory.kt
@@ -18,6 +18,7 @@ package org.radarbase.output
 
 import org.radarbase.output.accounting.Accountant
 import org.radarbase.output.accounting.OffsetPersistenceFactory
+import org.radarbase.output.accounting.RedisHolder
 import org.radarbase.output.accounting.RemoteLockManager
 import org.radarbase.output.compression.Compression
 import org.radarbase.output.config.RestructureConfig
@@ -26,7 +27,6 @@ import org.radarbase.output.path.RecordPathFactory
 import org.radarbase.output.source.SourceStorage
 import org.radarbase.output.target.TargetStorage
 import org.radarbase.output.worker.FileCacheStore
-import redis.clients.jedis.JedisPool
 import java.io.IOException
 
 /** Factory for all factory classes and settings.  */
@@ -38,7 +38,7 @@ interface FileStoreFactory {
     val recordConverter: RecordConverterFactory
     val config: RestructureConfig
     val remoteLockManager: RemoteLockManager
-    val redisPool: JedisPool
+    val redisHolder: RedisHolder
     val offsetPersistenceFactory: OffsetPersistenceFactory
 
     @Throws(IOException::class)

--- a/src/main/java/org/radarbase/output/accounting/OffsetIntervals.kt
+++ b/src/main/java/org/radarbase/output/accounting/OffsetIntervals.kt
@@ -179,7 +179,7 @@ class OffsetIntervals {
     private fun insert(index: Int, from: Long, to: Long, lastModified: Instant) {
         offsetsFrom.insert(index, from)
         offsetsTo.insert(index, to)
-        if (index >= lastProcessed.size) {
+        if (index > lastProcessed.size) {
             lastProcessed.add(lastModified)
         } else {
             lastProcessed.add(index, lastModified)

--- a/src/main/java/org/radarbase/output/accounting/RedisHolder.kt
+++ b/src/main/java/org/radarbase/output/accounting/RedisHolder.kt
@@ -1,0 +1,24 @@
+package org.radarbase.output.accounting
+
+import redis.clients.jedis.Jedis
+import redis.clients.jedis.JedisPool
+import redis.clients.jedis.exceptions.JedisException
+import java.io.Closeable
+import java.io.IOException
+
+class RedisHolder(private val jedisPool: JedisPool): Closeable {
+    @Throws(IOException::class)
+    fun <T> execute(routine: (Jedis) -> T): T {
+        return try {
+            jedisPool.resource.use {
+                routine(it)
+            }
+        } catch (ex: JedisException) {
+            throw IOException(ex)
+        }
+    }
+
+    override fun close() {
+        jedisPool.close()
+    }
+}

--- a/src/main/java/org/radarbase/output/accounting/TopicPartitionOffsetRange.kt
+++ b/src/main/java/org/radarbase/output/accounting/TopicPartitionOffsetRange.kt
@@ -34,7 +34,13 @@ data class TopicPartitionOffsetRange(
             TopicPartition(topic, partition),
             OffsetRangeSet.Range(offsetFrom, offsetTo, lastModified))
 
-    override fun toString(): String = "$topic+$partition+${range.from}+${range.to} (${range.lastProcessed})"
+    override fun toString(): String {
+        return if (range.to == null) {
+            "$topic+$partition+${range.from} (${range.lastProcessed})"
+        } else {
+            "$topic+$partition+${range.from}+${range.to} (${range.lastProcessed})"
+        }
+    }
 
     fun mapRange(modification: (OffsetRangeSet.Range) -> OffsetRangeSet.Range) = copy(range = modification(range))
 

--- a/src/main/java/org/radarbase/output/config/RestructureConfig.kt
+++ b/src/main/java/org/radarbase/output/config/RestructureConfig.kt
@@ -318,20 +318,32 @@ data class S3Config(
         /** Secret key belonging to access token. */
         val secretKey: String,
         /** Bucket name. */
-        val bucket: String) {
-    fun createS3Client() = MinioClient.Builder()
+        val bucket: String,
+        /** If no endOffset is in the filename, read it from object tags. */
+        val endOffsetFromTags: Boolean = false
+) {
+    fun createS3Client(): MinioClient = MinioClient.Builder()
             .endpoint(endpoint)
             .credentials(accessToken, secretKey)
             .build()
 }
 
 data class AzureConfig(
+        /** URL to reach object store at. */
         val endpoint: String,
+        /** Name of the Azure Blob Storage container. */
         val container: String,
+        /** If no endOffset is in the filename, read it from object metadata. */
+        val endOffsetFromMetadata: Boolean = false,
+        /** Azure username. */
         val username: String?,
+        /** Azure password. */
         val password: String?,
+        /** Shared Azure Blob Storage account name. */
         val accountName: String?,
+        /** Shared Azure Blob Storage account key. */
         val accountKey: String?,
+        /** Azure SAS token for a configured service. */
         val sasToken: String?
 ) {
     fun createAzureClient(): BlobServiceClient = BlobServiceClientBuilder().apply {

--- a/src/main/java/org/radarbase/output/config/RestructureConfig.kt
+++ b/src/main/java/org/radarbase/output/config/RestructureConfig.kt
@@ -107,9 +107,9 @@ data class ServiceConfig(
 }
 
 data class CleanerConfig(
-        /** Whether to enable the cleaner */
+        /** Whether to enable the cleaner. */
         val enable: Boolean = false,
-        /** How often to run the cleaner */
+        /** How often to run the cleaner in seconds. */
         val interval: Long = 1260L,
         /** Age in days after an avro file can be removed. Must be strictly positive. */
         val age: Int = 7) {

--- a/src/main/java/org/radarbase/output/config/RestructureConfig.kt
+++ b/src/main/java/org/radarbase/output/config/RestructureConfig.kt
@@ -319,7 +319,10 @@ data class S3Config(
         val secretKey: String,
         /** Bucket name. */
         val bucket: String) {
-    fun createS3Client() = MinioClient(endpoint, accessToken, secretKey)
+    fun createS3Client() = MinioClient.Builder()
+            .endpoint(endpoint)
+            .credentials(accessToken, secretKey)
+            .build()
 }
 
 data class AzureConfig(

--- a/src/main/java/org/radarbase/output/source/GeneralSourceStorageWalker.kt
+++ b/src/main/java/org/radarbase/output/source/GeneralSourceStorageWalker.kt
@@ -1,7 +1,6 @@
 package org.radarbase.output.source
 
 import java.nio.file.Path
-import java.time.Instant
 
 class GeneralSourceStorageWalker(
         private val kafkaStorage: SourceStorage
@@ -11,7 +10,7 @@ class GeneralSourceStorageWalker(
                 val filename = status.path.fileName.toString()
                 when {
                     status.isDirectory && filename != "+tmp" -> walkRecords(topic, status.path)
-                    filename.endsWith(".avro") -> sequenceOf(TopicFile(topic, status.path, status.lastModified ?: Instant.now()))
+                    filename.endsWith(".avro") -> sequenceOf(kafkaStorage.createTopicFile(topic, status))
                     else -> emptySequence()
                 }
             }

--- a/src/main/java/org/radarbase/output/source/S3SourceStorage.kt
+++ b/src/main/java/org/radarbase/output/source/S3SourceStorage.kt
@@ -37,7 +37,10 @@ class S3SourceStorage(
             val tags = s3Client.getObjectTags(GetObjectTagsArgs.Builder().objectBuild(bucket, status.path))
             val endOffset = tags.get()["endOffset"]?.toLongOrNull()
             if (endOffset != null) {
-                topicFile = topicFile.copy(range = topicFile.range.mapRange { it.copy(to = endOffset) })
+                topicFile = topicFile.copy(
+                        range = topicFile.range.mapRange {
+                            it.copy(to = endOffset)
+                        })
             }
         }
 

--- a/src/main/java/org/radarbase/output/source/S3SourceStorage.kt
+++ b/src/main/java/org/radarbase/output/source/S3SourceStorage.kt
@@ -23,6 +23,7 @@ class S3SourceStorage(
             ListObjectsArgs.Builder().bucketBuild(bucket) {
                 prefix("$path/")
                 recursive(false)
+                useUrlEncodingType(false)
             })
             .asSequence()
             .map {

--- a/src/main/java/org/radarbase/output/source/S3SourceStorage.kt
+++ b/src/main/java/org/radarbase/output/source/S3SourceStorage.kt
@@ -31,16 +31,17 @@ class S3SourceStorage(
             }
 
     override fun createTopicFile(topic: String, status: SimpleFileStatus): TopicFile {
-        val topicFile = super.createTopicFile(topic, status)
-        return if (topicFile.range.range.to == null) {
+        var topicFile = super.createTopicFile(topic, status)
+
+        if (topicFile.range.range.to == null) {
             val tags = s3Client.getObjectTags(GetObjectTagsArgs.Builder().objectBuild(bucket, status.path))
             val endOffset = tags.get()["endOffset"]?.toLongOrNull()
             if (endOffset != null) {
-                topicFile.copy(range = topicFile.range.mapRange { it.copy(to = endOffset) })
-            } else {
-                topicFile
+                topicFile = topicFile.copy(range = topicFile.range.mapRange { it.copy(to = endOffset) })
             }
-        } else topicFile
+        }
+
+        return topicFile
     }
 
     override fun delete(path: Path) {

--- a/src/main/java/org/radarbase/output/source/SourceStorage.kt
+++ b/src/main/java/org/radarbase/output/source/SourceStorage.kt
@@ -1,6 +1,7 @@
 package org.radarbase.output.source
 
 import org.apache.avro.file.SeekableInput
+import org.radarbase.output.accounting.TopicPartitionOffsetRange
 import java.io.Closeable
 import java.nio.file.Path
 import java.time.Instant
@@ -15,7 +16,9 @@ interface SourceStorage {
     /** Delete given file. Will not delete any directories. */
     fun delete(path: Path)
     fun createTopicFile(topic: String, status: SimpleFileStatus): TopicFile {
-        return TopicFile(topic, status.path, status.lastModified ?: Instant.now())
+        val lastModified = status.lastModified ?: Instant.now()
+        val range = TopicPartitionOffsetRange.parseFilename(status.path.fileName.toString(), lastModified)
+        return TopicFile(topic, status.path, lastModified, range)
     }
 
     /** Find records and topics. */

--- a/src/main/java/org/radarbase/output/source/SourceStorage.kt
+++ b/src/main/java/org/radarbase/output/source/SourceStorage.kt
@@ -3,6 +3,7 @@ package org.radarbase.output.source
 import org.apache.avro.file.SeekableInput
 import java.io.Closeable
 import java.nio.file.Path
+import java.time.Instant
 
 /** Source storage type. */
 interface SourceStorage {
@@ -13,6 +14,10 @@ interface SourceStorage {
 
     /** Delete given file. Will not delete any directories. */
     fun delete(path: Path)
+    fun createTopicFile(topic: String, status: SimpleFileStatus): TopicFile {
+        return TopicFile(topic, status.path, status.lastModified ?: Instant.now())
+    }
+
     /** Find records and topics. */
     val walker: SourceStorageWalker
 

--- a/src/main/java/org/radarbase/output/source/SourceStorageFactory.kt
+++ b/src/main/java/org/radarbase/output/source/SourceStorageFactory.kt
@@ -20,7 +20,7 @@ class SourceStorageFactory(private val resourceConfig: ResourceConfig, private v
         ResourceType.S3 -> {
             val s3Config = requireNotNull(resourceConfig.s3)
             val minioClient = requireNotNull(s3SourceClient)
-            S3SourceStorage(minioClient, s3Config.bucket, tempPath)
+            S3SourceStorage(minioClient, s3Config, tempPath)
         }
         ResourceType.HDFS -> {
             val hdfsConfig = requireNotNull(resourceConfig.hdfs)
@@ -29,8 +29,8 @@ class SourceStorageFactory(private val resourceConfig: ResourceConfig, private v
         }
         ResourceType.AZURE -> {
             val azureClient = requireNotNull(azureSourceClient)
-            val config = requireNotNull(resourceConfig.azure)
-            AzureSourceStorage(azureClient, config.container, tempPath)
+            val azureConfig = requireNotNull(resourceConfig.azure)
+            AzureSourceStorage(azureClient, azureConfig, tempPath)
         }
         else -> throw IllegalStateException("Cannot create kafka storage for type ${resourceConfig.sourceType}")
     }

--- a/src/main/java/org/radarbase/output/source/TopicFileList.kt
+++ b/src/main/java/org/radarbase/output/source/TopicFileList.kt
@@ -11,8 +11,8 @@ data class TopicFileList(val topic: String, val files: List<TopicFile>) {
     val numberOfFiles: Int = this.files.size
 }
 
-data class TopicFile(val topic: String, val path: Path, val lastModified: Instant) {
-    val range: TopicPartitionOffsetRange = TopicPartitionOffsetRange.parseFilename(path.fileName.toString(), lastModified)
+data class TopicFile(val topic: String, val path: Path, val lastModified: Instant, val range: TopicPartitionOffsetRange) {
+    constructor(topic: String, path: Path, lastModified: Instant) : this(topic, path, lastModified, TopicPartitionOffsetRange.parseFilename(path.fileName.toString(), lastModified))
     val size: Long? = range.range.size
 }
 

--- a/src/main/java/org/radarbase/output/util/Path.kt
+++ b/src/main/java/org/radarbase/output/util/Path.kt
@@ -1,10 +1,26 @@
 package org.radarbase.output.util
 
+import io.minio.BucketArgs
+import io.minio.ObjectArgs
 import java.nio.file.Path
 import java.nio.file.Paths
 
 private val rootPath = Paths.get("/")
 
-internal fun Path.toKey() = if (startsWith(rootPath)) {
+fun Path.toKey() = if (startsWith(rootPath)) {
     rootPath.relativize(this).toString()
 } else toString()
+
+
+inline fun <S: BucketArgs, reified T: BucketArgs.Builder<out T, out S>> T.bucketBuild(bucket: String, configure: T.() -> T = { this }): S {
+    bucket(bucket)
+    configure()
+    return build()
+}
+
+inline fun <S: ObjectArgs, reified T: ObjectArgs.Builder<out T, out S>> T.objectBuild(bucket: String, path: Path, configure: T.() -> T = { this }): S {
+    return bucketBuild(bucket) {
+        `object`(path.toKey())
+        configure()
+    }
+}

--- a/src/main/java/org/radarbase/output/worker/Job.kt
+++ b/src/main/java/org/radarbase/output/worker/Job.kt
@@ -1,0 +1,40 @@
+package org.radarbase.output.worker
+
+import org.radarbase.output.util.ProgressBar.Companion.format
+import org.radarbase.output.util.TimeUtil.durationSince
+import org.radarbase.output.util.Timer
+import org.slf4j.LoggerFactory
+import java.time.Instant
+import java.util.concurrent.Future
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+class Job(val name: String, val isEnabled: Boolean, val intervalSeconds: Long, val work: () -> Unit) {
+    fun run() {
+        val timeStart = Instant.now()
+        try {
+            work()
+            logger.info("Job {} completed in {}", name, timeStart.durationSince().format())
+        } catch (e: InterruptedException) {
+            logger.error("Job {} interrupted", name)
+        } catch (ex: Throwable) {
+            logger.error("Failed to run job {}", name, ex)
+        } finally {
+            if (Timer.isEnabled) {
+                logger.info("Job {} {}", name, Timer)
+                Timer.reset()
+            }
+        }
+    }
+
+    fun schedule(executorService: ScheduledExecutorService): Future<*> {
+        return executorService.scheduleAtFixedRate(::run,
+                intervalSeconds / 4,
+                intervalSeconds,
+                TimeUnit.SECONDS)
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(Job::class.java)
+    }
+}

--- a/src/main/java/org/radarbase/output/worker/Job.kt
+++ b/src/main/java/org/radarbase/output/worker/Job.kt
@@ -9,9 +9,15 @@ import java.util.concurrent.Future
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
-class Job(val name: String, val isEnabled: Boolean, val intervalSeconds: Long, val work: () -> Unit) {
+class Job(
+        val name: String,
+        val isEnabled: Boolean,
+        private val intervalSeconds: Long,
+        val work: () -> Unit
+) {
     fun run() {
         val timeStart = Instant.now()
+        logger.info("Job {} started", name)
         try {
             work()
             logger.info("Job {} completed in {}", name, timeStart.durationSince().format())
@@ -27,12 +33,12 @@ class Job(val name: String, val isEnabled: Boolean, val intervalSeconds: Long, v
         }
     }
 
-    fun schedule(executorService: ScheduledExecutorService): Future<*> {
-        return executorService.scheduleAtFixedRate(::run,
-                intervalSeconds / 4,
-                intervalSeconds,
-                TimeUnit.SECONDS)
-    }
+    fun schedule(
+            executorService: ScheduledExecutorService
+    ): Future<*> = executorService.scheduleAtFixedRate(::run,
+            intervalSeconds / 4,
+            intervalSeconds,
+            TimeUnit.SECONDS)
 
     companion object {
         private val logger = LoggerFactory.getLogger(Job::class.java)


### PR DESCRIPTION
Changes since version 1.1.2:
- Updated Minio, including updated syntax
- Read object tags from S3 and object metadata in Azure to determine end offset of file.
- Wrapped `JedisPool` in a `RedisHolder` that does converts thrown `JedisException` to `IOException`.
- Wrapped RadarKafkaRestructure and SourceDataCleaner into a Job to manage starting and catching exceptions. This fixes the occurrence that an OutOfMemoryException was not properly handled.
- Fixed off-by-one error in OffsetIntervals
- Reduced deduplication memory consumption, especially if the `format: deduplication: distinctFields` property is set.