### PR TITLE
Tmp dir hotfix: release 1.1.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'org.radarbase'
-version '1.1.4'
+version '1.1.4.1'
 mainClassName = 'org.radarbase.output.Application'
 
 sourceCompatibility = '1.8'

--- a/src/main/java/org/radarbase/output/cleaner/SourceDataCleaner.kt
+++ b/src/main/java/org/radarbase/output/cleaner/SourceDataCleaner.kt
@@ -62,8 +62,9 @@ class SourceDataCleaner(
         return try {
             lockManager.tryRunLocked(topic) {
                 Accountant(fileStoreFactory, topic).use { accountant ->
-                    val extractionCheck = TimestampExtractionCheck(sourceStorage, fileStoreFactory)
-                    deleteOldFiles(accountant, extractionCheck, topic, topicPath).toLong()
+                    TimestampExtractionCheck(sourceStorage, fileStoreFactory).use { extractionCheck ->
+                        deleteOldFiles(accountant, extractionCheck, topic, topicPath).toLong()
+                    }
                 }
             }
         } catch (ex: IOException) {

--- a/src/main/java/org/radarbase/output/cleaner/TimestampExtractionCheck.kt
+++ b/src/main/java/org/radarbase/output/cleaner/TimestampExtractionCheck.kt
@@ -47,7 +47,6 @@ class TimestampExtractionCheck(
         reader.close()
     }
 
-
     private fun containsRecord(topicFile: TopicFile, offset: Long, record: GenericRecord): Boolean {
         var suffix = 0
 

--- a/src/main/java/org/radarbase/output/util/TemporaryDirectory.kt
+++ b/src/main/java/org/radarbase/output/util/TemporaryDirectory.kt
@@ -46,15 +46,7 @@ constructor(root: Path, prefix: String) : Closeable {
     private fun doClose() {
         try {
             // Ignore errors the first time
-            Files.walk(path)
-                    .sorted(Comparator.reverseOrder())
-                    .forEach {
-                        try {
-                            Files.deleteIfExists(it)
-                        } catch (ex: Exception) {
-                            // do nothing
-                        }
-                    }
+            deleteTree()
         } catch (ex: IOException) {
             // ignore the first time
         }
@@ -68,20 +60,24 @@ constructor(root: Path, prefix: String) : Closeable {
                     Thread.currentThread().interrupt()
                 }
 
-                Files.walk(path)
-                        .sorted(Comparator.reverseOrder())
-                        .forEach {
-                            try {
-                                Files.deleteIfExists(it)
-                            } catch (ex: Exception) {
-                                logger.warn("Cannot delete temporary path {}: {}",
-                                        it, ex.toString())
-                            }
-                        }
+                deleteTree()
             }
         } catch (ex: IOException) {
             logger.warn("Cannot delete temporary directory {}: {}", path, ex.toString())
         }
+    }
+
+    private fun deleteTree() {
+        Files.walk(path)
+                .sorted(Comparator.reverseOrder())
+                .forEach {
+                    try {
+                        Files.deleteIfExists(it)
+                    } catch (ex: Exception) {
+                        logger.warn("Cannot delete temporary path {}: {}",
+                                it, ex.toString())
+                    }
+                }
     }
 
     override fun close() {
@@ -91,7 +87,6 @@ constructor(root: Path, prefix: String) : Closeable {
         } catch (ex: IllegalStateException) {
             // already shutting down
         }
-
     }
 
     companion object {


### PR DESCRIPTION
Changes since release 1.1.4:
- Fixes an issue where the data checking part does not remove its temporary directories. This may cause storage inodes to fill up.