### PR TITLE
Add per-topic formatting with record data lookup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          distribution: zulu
+          distribution: temurin
           java-version: 17
 
       - name: Setup Gradle

--- a/.github/workflows/publish_snapshots.yml
+++ b/.github/workflows/publish_snapshots.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          distribution: zulu
+          distribution: temurin
           java-version: 17
 
       - name: Setup Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          distribution: zulu
+          distribution: temurin
           java-version: 17
 
       - name: Setup Gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM gradle:7.4-jdk17 AS builder
+FROM --platform=$BUILDPLATFORM gradle:7.5-jdk17 AS builder
 
 RUN mkdir /code
 WORKDIR /code

--- a/README.md
+++ b/README.md
@@ -138,16 +138,16 @@ target:
 
 Secrets can be provided as environment variables as well:
 
-| Environment variable | Corresponding value |
-| --- | --- |
-| `SOURCE_S3_ACCESS_TOKEN` | `source.s3.accessToken` |
-| `SOURCE_S3_SECRET_KEY` | `source.s3.secretKey` |
-| `SOURCE_AZURE_USERNAME` | `source.azure.username` |
-| `SOURCE_AZURE_PASSWORD` | `source.azure.password` |
+| Environment variable        | Corresponding value        |
+|-----------------------------|----------------------------|
+| `SOURCE_S3_ACCESS_TOKEN`    | `source.s3.accessToken`    |
+| `SOURCE_S3_SECRET_KEY`      | `source.s3.secretKey`      |
+| `SOURCE_AZURE_USERNAME`     | `source.azure.username`    |
+| `SOURCE_AZURE_PASSWORD`     | `source.azure.password`    |
 | `SOURCE_AZURE_ACCOUNT_NAME` | `source.azure.accountName` |
-| `SOURCE_AZURE_ACCOUNT_KEY` | `source.azure.accountKey` |
-| `SOURCE_AZURE_SAS_TOKEN` | `source.azure.sasToken` |
-| `REDIS_URL` | `redis.url` |
+| `SOURCE_AZURE_ACCOUNT_KEY`  | `source.azure.accountKey`  |
+| `SOURCE_AZURE_SAS_TOKEN`    | `source.azure.sasToken`    |
+| `REDIS_URL`                 | `redis.url`                |
 
 Replace `SOURCE` with `TARGET` in the variables above to configure the target storage.
 
@@ -192,10 +192,10 @@ Now the `radar-output-restructure` command should be available.
 To implement alternative storage paths, storage drivers or storage formats, put your custom JAR in
 `$APP_DIR/lib/radar-output-plugins`. To load them, use the following options:
 
-| Parameter                   | Base class                                          | Behaviour                                  | Default                   |
-| --------------------------- | --------------------------------------------------- | ------------------------------------------ | ------------------------- |
-| `paths: factory: ...`       | `org.radarbase.output.path.RecordPathFactory`         | Factory to create output path names with.  | ObservationKeyPathFactory |
-| `format: factory: ...`      | `org.radarbase.output.format.FormatFactory`           | Factory for output formats.                | FormatFactory             |
-| `compression: factory: ...` | `org.radarbase.output.compression.CompressionFactory` | Factory class to use for data compression. | CompressionFactory        |
+| Parameter                   | Base class                                            | Behaviour                                  | Default              |
+|-----------------------------|-------------------------------------------------------|--------------------------------------------|----------------------|
+| `paths: factory: ...`       | `org.radarbase.output.path.RecordPathFactory`         | Factory to create output path names with.  | FormattedPathFactory |
+| `format: factory: ...`      | `org.radarbase.output.format.FormatFactory`           | Factory for output formats.                | FormatFactory        |
+| `compression: factory: ...` | `org.radarbase.output.compression.CompressionFactory` | Factory class to use for data compression. | CompressionFactory   |
 
 The respective `<type>: properties: {}` configuration parameters can be used to provide custom configuration of the factory. This configuration will be passed to the `Plugin#init(Map<String, String>)` method.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,6 +141,7 @@ tasks.withType<KotlinCompile> {
         jvmTarget = "17"
         apiVersion = "1.6"
         languageVersion = "1.6"
+        freeCompilerArgs = listOf("-opt-in=kotlin.RequiresOptIn")
     }
 }
 

--- a/restructure.yml
+++ b/restructure.yml
@@ -163,9 +163,6 @@ topics:
       enable: false
   questionnaire_response:
     # Specify an alternative path format.
-    pathFormat: ${projectId}/${userId}/${topic}/${value:name}/${filename}
-    pathFormatPlugins: |
-      org.radarbase.output.path.FixedPathFormatterPlugin
-      org.radarbase.output.path.TimePathFormatterPlugin
-      org.radarbase.output.path.KeyPathFormatterPlugin
-      org.radarbase.output.path.ValuePathFormatterPlugin
+    pathProperties:
+      format: ${projectId}/${userId}/${topic}/${value:name}/${filename}
+      plugins: fixed value

--- a/restructure.yml
+++ b/restructure.yml
@@ -136,6 +136,7 @@ paths:
   # Additional properties
   # properties:
   #   format: ${projectId}/${userId}/${topic}/${time:mm}/${time:YYYYmmDD_HH'00'}${attempt}${extension}
+  #   plugins: fixed time key value org.example.plugin.MyPathPlugin
 
 # Individual topic configuration
 topics:
@@ -160,3 +161,11 @@ topics:
     # Disable deduplication
     deduplication:
       enable: false
+  questionnaire_response:
+    # Specify an alternative path format.
+    pathFormat: ${projectId}/${userId}/${topic}/${value:name}/${filename}
+    pathFormatPlugins: |
+      org.radarbase.output.path.FixedPathFormatterPlugin
+      org.radarbase.output.path.TimePathFormatterPlugin
+      org.radarbase.output.path.KeyPathFormatterPlugin
+      org.radarbase.output.path.ValuePathFormatterPlugin

--- a/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
+++ b/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
@@ -100,7 +100,7 @@ class RestructureS3IntegrationTest {
                 assertEquals(csvContents, targetContent.toString(UTF_8))
             }
 
-            withContext(Dispatchers.IO) {
+            return@coroutineScope withContext(Dispatchers.IO) {
                 targetClient.listObjects(
                     ListObjectsArgs.Builder().bucketBuild(targetConfig.bucket) {
                         prefix("output")
@@ -108,8 +108,7 @@ class RestructureS3IntegrationTest {
                         useUrlEncodingType(false)
                     }
                 )
-                    .map { it.get().objectName() }
-                    .toHashSet()
+                    .mapTo(HashSet()) { it.get().objectName() }
             }
         }
 

--- a/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
+++ b/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
@@ -32,7 +32,9 @@ class RestructureS3IntegrationTest {
         )
         val topicConfig = mapOf(
             "application_server_status" to TopicConfig(
-                pathFormat = "\${projectId}/\${userId}/\${topic}/\${value:serverStatus}/\${filename}"
+                pathFormat = mapOf(
+                    "format" to "\${projectId}/\${userId}/\${topic}/\${value:serverStatus}/\${filename}"
+                )
             )
         )
         val config = RestructureConfig(

--- a/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
+++ b/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
@@ -25,12 +25,7 @@ class RestructureS3IntegrationTest {
             secretKey = "minioadmin",
             bucket = "source",
         )
-        val targetConfig = S3Config(
-            endpoint = "http://localhost:9000",
-            accessToken = "minioadmin",
-            secretKey = "minioadmin",
-            bucket = "target",
-        )
+        val targetConfig = sourceConfig.copy(bucket = "target")
         val topicConfig = mapOf(
             "application_server_status" to TopicConfig(
                 pathProperties = mapOf(

--- a/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
+++ b/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
@@ -32,7 +32,7 @@ class RestructureS3IntegrationTest {
         )
         val topicConfig = mapOf(
             "application_server_status" to TopicConfig(
-                pathFormat = mapOf(
+                pathProperties = mapOf(
                     "format" to "\${projectId}/\${userId}/\${topic}/\${value:serverStatus}/\${filename}"
                 )
             )

--- a/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
+++ b/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
@@ -30,11 +30,17 @@ class RestructureS3IntegrationTest {
             secretKey = "minioadmin",
             bucket = "target",
         )
+        val topicConfig = mapOf(
+            "application_server_status" to TopicConfig(
+                pathFormat = "\${projectId}/\${userId}/\${topic}/\${value:serverStatus}/\${filename}"
+            )
+        )
         val config = RestructureConfig(
             source = ResourceConfig("s3", s3 = sourceConfig),
             target = ResourceConfig("s3", s3 = targetConfig),
             paths = PathConfig(inputs = listOf(Paths.get("in"))),
-            worker = WorkerConfig(minimumFileAge = 0L)
+            worker = WorkerConfig(minimumFileAge = 0L),
+            topics = topicConfig,
         )
         val application = Application(config)
         val sourceClient = sourceConfig.createS3Client()
@@ -72,7 +78,7 @@ class RestructureS3IntegrationTest {
         }
 
         val firstParticipantOutput =
-            "output/STAGING_PROJECT/1543bc93-3c17-4381-89a5-c5d6272b827c/application_server_status"
+            "output/STAGING_PROJECT/1543bc93-3c17-4381-89a5-c5d6272b827c/application_server_status/CONNECTED"
         val secondParticipantOutput =
             "output/radar-test-root/4ab9b985-6eec-4e51-9a29-f4c571c89f99/android_phone_acceleration"
 

--- a/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
+++ b/src/integrationTest/java/org/radarbase/output/RestructureS3IntegrationTest.kt
@@ -14,6 +14,7 @@ import org.radarbase.output.util.objectBuild
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Paths
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class RestructureS3IntegrationTest {
     @Test
     fun integration() = runTest {

--- a/src/integrationTest/java/org/radarbase/output/accounting/OffsetRangeRedisTest.kt
+++ b/src/integrationTest/java/org/radarbase/output/accounting/OffsetRangeRedisTest.kt
@@ -1,5 +1,6 @@
 package org.radarbase.output.accounting
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
@@ -13,6 +14,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.Instant
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class OffsetRangeRedisTest {
     private lateinit var testFile: Path
     private lateinit var redisHolder: RedisHolder

--- a/src/integrationTest/java/org/radarbase/output/accounting/RedisRemoteLockManagerTest.kt
+++ b/src/integrationTest/java/org/radarbase/output/accounting/RedisRemoteLockManagerTest.kt
@@ -1,5 +1,6 @@
 package org.radarbase.output.accounting
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.not
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test
 import org.radarbase.output.util.SuspendedCloseable.Companion.useSuspended
 import redis.clients.jedis.JedisPool
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class RedisRemoteLockManagerTest {
     private lateinit var redisHolder: RedisHolder
     private lateinit var lockManager1: RemoteLockManager

--- a/src/main/java/org/radarbase/output/Application.kt
+++ b/src/main/java/org/radarbase/output/Application.kt
@@ -58,6 +58,7 @@ class Application(
     override val pathFactory: RecordPathFactory = config.paths.createFactory().apply {
         extension = recordConverter.extension + compression.extension
         root = config.paths.output
+        addTopicConfiguration(config.topics)
     }
 
     private val sourceStorageFactory = SourceStorageFactory(config.source, config.paths.temp)

--- a/src/main/java/org/radarbase/output/Application.kt
+++ b/src/main/java/org/radarbase/output/Application.kt
@@ -56,6 +56,7 @@ class Application(
     override val recordConverter: RecordConverterFactory = config.format.createConverter()
     override val compression: Compression = config.compression.createCompression()
     override val pathFactory: RecordPathFactory = config.paths.createFactory().apply {
+        fileStoreFactory = this@Application
         extension = recordConverter.extension + compression.extension
         root = config.paths.output
         addTopicConfiguration(config.topics)

--- a/src/main/java/org/radarbase/output/config/PathConfig.kt
+++ b/src/main/java/org/radarbase/output/config/PathConfig.kt
@@ -5,9 +5,10 @@ import org.radarbase.output.path.RecordPathFactory
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.io.path.createTempDirectory
+import kotlin.reflect.jvm.jvmName
 
 data class PathConfig(
-    override val factory: String = FormattedPathFactory::class.qualifiedName!!,
+    override val factory: String = FormattedPathFactory::class.jvmName,
     override val properties: Map<String, String> = emptyMap(),
     /** Input paths referencing the source resource. */
     val inputs: List<Path> = emptyList(),

--- a/src/main/java/org/radarbase/output/config/TopicConfig.kt
+++ b/src/main/java/org/radarbase/output/config/TopicConfig.kt
@@ -14,7 +14,7 @@ data class TopicConfig(
      * Specify alternative path format, following
      * [org.radarbase.output.path.FormattedPathFactory] format.
      */
-    val pathFormat: Map<String, String> = emptyMap(),
+    val pathProperties: Map<String, String> = emptyMap(),
 ) {
     fun deduplication(deduplicationDefault: DeduplicationConfig): DeduplicationConfig =
         deduplication

--- a/src/main/java/org/radarbase/output/config/TopicConfig.kt
+++ b/src/main/java/org/radarbase/output/config/TopicConfig.kt
@@ -10,6 +10,11 @@ data class TopicConfig(
      * in the service.
      */
     val excludeFromDelete: Boolean = false,
+    /**
+     * Specify alternative path format, following
+     * [org.radarbase.output.path.FormattedPathFactory] format.
+     */
+    val pathFormat: String? = null,
 ) {
     fun deduplication(deduplicationDefault: DeduplicationConfig): DeduplicationConfig =
         deduplication

--- a/src/main/java/org/radarbase/output/config/TopicConfig.kt
+++ b/src/main/java/org/radarbase/output/config/TopicConfig.kt
@@ -14,7 +14,7 @@ data class TopicConfig(
      * Specify alternative path format, following
      * [org.radarbase.output.path.FormattedPathFactory] format.
      */
-    val pathFormat: String? = null,
+    val pathFormat: Map<String, String> = emptyMap(),
 ) {
     fun deduplication(deduplicationDefault: DeduplicationConfig): DeduplicationConfig =
         deduplication

--- a/src/main/java/org/radarbase/output/format/CsvAvroConverterFactory.kt
+++ b/src/main/java/org/radarbase/output/format/CsvAvroConverterFactory.kt
@@ -38,10 +38,12 @@ class CsvAvroConverterFactory : RecordConverterFactory {
                 if (header == null) return false
                 val fields = fieldIndexes(header, distinctFields, ignoreFields)
                 var count = 0
-                val lineMap = lines
-                    .onEach { count += 1 }
-                    .mapIndexed { idx, line -> Pair(ArrayWrapper(line.byIndex(fields)), idx) }
-                    .toMap(HashMap())
+                val lineMap = buildMap {
+                    lines.forEachIndexed { idx, line ->
+                        count += 1
+                        put(ArrayWrapper(line.byIndex(fields)), idx)
+                    }
+                }
 
                 if (lineMap.size == count) {
                     logger.debug("File {} is already deduplicated. Skipping.", fileName)

--- a/src/main/java/org/radarbase/output/format/CsvAvroDataConverter.kt
+++ b/src/main/java/org/radarbase/output/format/CsvAvroDataConverter.kt
@@ -32,9 +32,7 @@ internal class CsvAvroDataConverter(
         for (field in schema.fields) {
             convertAvro(values, record.get(field.pos()), field.schema(), field.name())
         }
-        if (values.size < headers.size) {
-            throw IllegalArgumentException("Values and headers do not match")
-        }
+        require(values.size >= headers.size) { "Values and headers do not match" }
         return values
     }
 

--- a/src/main/java/org/radarbase/output/path/FixedPathFormatterPlugin.kt
+++ b/src/main/java/org/radarbase/output/path/FixedPathFormatterPlugin.kt
@@ -1,0 +1,25 @@
+package org.radarbase.output.path
+
+import org.radarbase.output.path.RecordPathFactory.Companion.sanitizeId
+
+class FixedPathFormatterPlugin : PathFormatterPlugin() {
+    override val allowedFormats: String = lookupTable.keys.joinToString(separator = ", ")
+
+    override fun createLookupTable(
+        parameterNames: Set<String>,
+    ): Map<String, PathFormatParameters.() -> String> = lookupTable.filterKeys { it in parameterNames }
+
+    companion object {
+        val lookupTable = mapOf<String, PathFormatParameters.() -> String>(
+            "projectId" to { sanitizeId(key.get("projectId"), "unknown-project") },
+            "userId" to { sanitizeId(key.get("userId"), "unknown-user") },
+            "sourceId" to { sanitizeId(key.get("sourceId"), "unknown-source") },
+            "topic" to { topic },
+            "filename" to { timeBin + attempt.toAttemptSuffix() + extension },
+            "attempt" to { attempt.toAttemptSuffix() },
+            "extension" to { extension },
+        )
+
+        private fun Int.toAttemptSuffix() = if (this == 0) "" else "_$this"
+    }
+}

--- a/src/main/java/org/radarbase/output/path/FormattedPathFactory.kt
+++ b/src/main/java/org/radarbase/output/path/FormattedPathFactory.kt
@@ -90,7 +90,7 @@ open class FormattedPathFactory : RecordPathFactory() {
         internal const val DEFAULT_FORMAT_PLUGINS = "fixed time key value"
         private val logger = LoggerFactory.getLogger(FormattedPathFactory::class.java)
 
-        private fun String.toPathFormatterPlugin(): PathFormatterPlugin? = when (this) {
+        internal fun String.toPathFormatterPlugin(): PathFormatterPlugin? = when (this) {
             "fixed" -> FixedPathFormatterPlugin()
             "time" -> TimePathFormatterPlugin()
             "key" -> KeyPathFormatterPlugin()

--- a/src/main/java/org/radarbase/output/path/FormattedPathFactory.kt
+++ b/src/main/java/org/radarbase/output/path/FormattedPathFactory.kt
@@ -59,12 +59,12 @@ open class FormattedPathFactory : RecordPathFactory() {
 
     override fun addTopicConfiguration(topicConfig: Map<String, TopicConfig>) {
         topicFormatters = topicConfig
-            .filter { (_, config) -> config.pathFormat.isNotEmpty() }
+            .filter { (_, config) -> config.pathProperties.isNotEmpty() }
             .mapValues { (_, config) ->
-                val topicFormat = config.pathFormat.getOrDefault("format", format)
-                val pluginClassNames = config.pathFormat["plugins"]
+                val topicFormat = config.pathProperties.getOrDefault("format", format)
+                val pluginClassNames = config.pathProperties["plugins"]
                 val topicPlugins = if (pluginClassNames != null) {
-                    instantiatePlugins(pluginClassNames, properties + config.pathFormat)
+                    instantiatePlugins(pluginClassNames, properties + config.pathProperties)
                 } else plugins
 
                 PathFormatter(topicFormat, topicPlugins)

--- a/src/main/java/org/radarbase/output/path/FormattedPathFactory.kt
+++ b/src/main/java/org/radarbase/output/path/FormattedPathFactory.kt
@@ -86,8 +86,8 @@ open class FormattedPathFactory : RecordPathFactory() {
     ): String = sanitizeId(key.get("sourceId"), "unknown-source")
 
     companion object {
-        private const val DEFAULT_FORMAT = "\${projectId}/\${userId}/\${topic}/\${filename}"
-        private const val DEFAULT_FORMAT_PLUGINS = "fixed time key value"
+        internal const val DEFAULT_FORMAT = "\${projectId}/\${userId}/\${topic}/\${filename}"
+        internal const val DEFAULT_FORMAT_PLUGINS = "fixed time key value"
         private val logger = LoggerFactory.getLogger(FormattedPathFactory::class.java)
 
         private fun String.toPathFormatterPlugin(): PathFormatterPlugin? = when (this) {

--- a/src/main/java/org/radarbase/output/path/FormattedPathFactory.kt
+++ b/src/main/java/org/radarbase/output/path/FormattedPathFactory.kt
@@ -17,56 +17,33 @@
 package org.radarbase.output.path
 
 import org.apache.avro.generic.GenericRecord
+import org.radarbase.output.config.TopicConfig
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
-import java.nio.file.Paths
 import java.time.Instant
-import java.time.ZoneOffset.UTC
-import java.time.format.DateTimeFormatter
 
 open class FormattedPathFactory : RecordPathFactory() {
-    lateinit var format: String
-    lateinit var timeParameters: Map<String, DateTimeFormatter>
+    private lateinit var formatter: PathFormatter
+    private var topicFormatters: Map<String, PathFormatter> = emptyMap()
 
     override fun init(properties: Map<String, String>) {
         super.init(properties)
 
-        format = properties["format"]
+        val format = properties["format"]
             ?: run {
                 logger.warn("Path format not provided, using {} instead", DEFAULT_FORMAT)
                 DEFAULT_FORMAT
             }
+        formatter = PathFormatter(format)
+    }
 
-        val parameters = "\\$\\{([^}]*)}".toRegex()
-            .findAll(format)
-            .map { it.groupValues[1] }
-            .toSet()
-
-        timeParameters = parameters
-            .filter { it.startsWith("time:") }
-            .associateWith { p ->
-                DateTimeFormatter
-                    .ofPattern(p.removePrefix("time:"))
-                    .withZone(UTC)
+    override fun addTopicConfiguration(topicConfig: Map<String, TopicConfig>) {
+        topicFormatters = buildMap {
+            topicConfig.forEach { (topic, config) ->
+                config.pathFormat
+                    ?.let { PathFormatter(it) }
+                    ?.let { put(topic, it) }
             }
-
-        val parameterNames = knownParameters + timeParameters.keys
-
-        val illegalParameters = parameters.filterNot { it in parameterNames }
-        if (illegalParameters.isNotEmpty()) {
-            throw IllegalArgumentException(
-                "Cannot use path format $format: unknown parameters $illegalParameters." +
-                    " Legal parameter names are time formats (e.g., \${time:YYYYmmDD}" +
-                    " or the following: $knownParameters",
-            )
-        }
-        if ("topic" !in parameters) {
-            throw IllegalArgumentException("Path must include topic parameter.")
-        }
-        if ("filename" !in parameters && ("extension" !in parameters || "attempt" !in parameters)) {
-            throw IllegalArgumentException(
-                "Path must include filename parameter or extension and attempt parameters."
-            )
         }
     }
 
@@ -76,50 +53,16 @@ open class FormattedPathFactory : RecordPathFactory() {
         value: GenericRecord,
         time: Instant?,
         attempt: Int,
-    ): Path {
-        val attemptSuffix = if (attempt == 0) "" else "_$attempt"
+    ): Path = (topicFormatters[topic] ?: formatter)
+        .format(topic, key, value, time, attempt, extension, ::getTimeBin)
 
-        val templatedParameters = mutableMapOf(
-            "projectId" to sanitizeId(key.get("projectId"), "unknown-project"),
-            "userId" to sanitizeId(key.get("userId"), "unknown-user"),
-            "sourceId" to sanitizeId(key.get("sourceId"), "unknown-source"),
-            "topic" to topic,
-            "filename" to getTimeBin(time) + attemptSuffix + extension,
-            "attempt" to attemptSuffix,
-            "extension" to extension,
-        )
-
-        templatedParameters += if (time != null) {
-            timeParameters.mapValues { (_, formatter) -> formatter.format(time) }
-        } else {
-            timeParameters.mapValues { "unknown-time" }
-        }
-
-        val path = templatedParameters.asSequence()
-            .fold(format) { p, (name, value) ->
-                p.replace("\${$name}", value)
-            }
-
-        return Paths.get(path)
-    }
-
-    override fun getCategory(key: GenericRecord, value: GenericRecord): String {
-        return sanitizeId(key.get("sourceId"), "unknown-source")
-    }
+    override fun getCategory(
+        key: GenericRecord,
+        value: GenericRecord,
+    ): String = sanitizeId(key.get("sourceId"), "unknown-source")
 
     companion object {
         private const val DEFAULT_FORMAT = "\${projectId}/\${userId}/\${topic}/\${filename}"
-
-        private val knownParameters = setOf(
-            "filename",
-            "topic",
-            "projectId",
-            "userId",
-            "sourceId",
-            "attempt",
-            "extension",
-        )
-
         private val logger = LoggerFactory.getLogger(FormattedPathFactory::class.java)
     }
 }

--- a/src/main/java/org/radarbase/output/path/FormattedPathFactory.kt
+++ b/src/main/java/org/radarbase/output/path/FormattedPathFactory.kt
@@ -35,12 +35,12 @@ open class FormattedPathFactory : RecordPathFactory() {
 
         format = properties["format"]
             ?: run {
-                logger.warn("Path format not provided, using {} instead", DEFAULT_FORMAT)
+                logger.warn("Path format not provided, using '{}' instead", DEFAULT_FORMAT)
                 DEFAULT_FORMAT
             }
         val pluginClassNames = properties["plugins"]
             ?: run {
-                logger.warn("Path format plugins not provided, using {} instead", DEFAULT_FORMAT_PLUGINS)
+                logger.warn("Path format plugins not provided, using '{}' instead", DEFAULT_FORMAT_PLUGINS)
                 DEFAULT_FORMAT_PLUGINS
             }
 

--- a/src/main/java/org/radarbase/output/path/KeyPathFormatterPlugin.kt
+++ b/src/main/java/org/radarbase/output/path/KeyPathFormatterPlugin.kt
@@ -2,7 +2,7 @@ package org.radarbase.output.path
 
 import org.radarbase.output.path.ValuePathFormatterPlugin.Companion.lookup
 
-class KeyPathFormatterPlugin: PathFormatterPlugin() {
+class KeyPathFormatterPlugin : PathFormatterPlugin() {
     override val allowedFormats: String = "key:my.key.index"
 
     override fun createLookupTable(

--- a/src/main/java/org/radarbase/output/path/KeyPathFormatterPlugin.kt
+++ b/src/main/java/org/radarbase/output/path/KeyPathFormatterPlugin.kt
@@ -1,0 +1,18 @@
+package org.radarbase.output.path
+
+import org.radarbase.output.path.ValuePathFormatterPlugin.Companion.lookup
+
+class KeyPathFormatterPlugin: PathFormatterPlugin() {
+    override val allowedFormats: String = "key:my.key.index"
+
+    override fun createLookupTable(
+        parameterNames: Set<String>
+    ): Map<String, (PathFormatParameters) -> String> = parameterNames
+        .filter { it.startsWith("key:") }
+        .associateWith { name ->
+            val index = name.removePrefix("key:").split('.')
+            return@associateWith { params ->
+                RecordPathFactory.sanitizeId(params.key.lookup(index), "unknown-key")
+            }
+        }
+}

--- a/src/main/java/org/radarbase/output/path/KeyPathFormatterPlugin.kt
+++ b/src/main/java/org/radarbase/output/path/KeyPathFormatterPlugin.kt
@@ -1,18 +1,18 @@
 package org.radarbase.output.path
 
+import org.radarbase.output.path.RecordPathFactory.Companion.sanitizeId
 import org.radarbase.output.path.ValuePathFormatterPlugin.Companion.lookup
 
 class KeyPathFormatterPlugin : PathFormatterPlugin() {
+    override val prefix: String = "key"
+
     override val allowedFormats: String = "key:my.key.index"
 
-    override fun createLookupTable(
-        parameterNames: Set<String>
-    ): Map<String, (PathFormatParameters) -> String> = parameterNames
-        .filter { it.startsWith("key:") }
-        .associateWith { name ->
-            val index = name.removePrefix("key:").split('.')
-            return@associateWith { params ->
-                RecordPathFactory.sanitizeId(params.key.lookup(index), "unknown-key")
-            }
+    override fun lookup(parameterContents: String): PathFormatParameters.() -> String {
+        val index = parameterContents.split('.')
+        require(index.none { it.isBlank() }) { "Cannot format key record with index $parameterContents" }
+        return {
+            sanitizeId(key.lookup(index), "unknown-key")
         }
+    }
 }

--- a/src/main/java/org/radarbase/output/path/PathFormatParameters.kt
+++ b/src/main/java/org/radarbase/output/path/PathFormatParameters.kt
@@ -1,0 +1,17 @@
+package org.radarbase.output.path
+
+import org.apache.avro.generic.GenericRecord
+import java.time.Instant
+
+data class PathFormatParameters(
+    val topic: String,
+    val key: GenericRecord,
+    val value: GenericRecord,
+    val time: Instant?,
+    val attempt: Int,
+    val extension: String,
+    val computeTimeBin: (time: Instant?) -> String,
+) {
+    val timeBin: String
+        get() = computeTimeBin(time)
+}

--- a/src/main/java/org/radarbase/output/path/PathFormatter.kt
+++ b/src/main/java/org/radarbase/output/path/PathFormatter.kt
@@ -29,8 +29,7 @@ class PathFormatter(
     init {
         val foundParameters = "\\$\\{([^}]*)}".toRegex()
             .findAll(format)
-            .map { it.groupValues[1] }
-            .toSet()
+            .mapTo(HashSet()) { it.groupValues[1] }
 
         parameterLookups = buildMap {
             plugins.forEach { plugin ->

--- a/src/main/java/org/radarbase/output/path/PathFormatter.kt
+++ b/src/main/java/org/radarbase/output/path/PathFormatter.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 The Hyve
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.radarbase.output.path
+
+import org.apache.avro.generic.GenericRecord
+import org.radarbase.output.path.RecordPathFactory.Companion.sanitizeId
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.time.Instant
+import java.time.ZoneOffset.UTC
+import java.time.format.DateTimeFormatter
+
+class PathFormatter(
+    private val format: String,
+) {
+    private val timeParameters: Map<String, DateTimeFormatter>
+    private val keyParameters: Map<String, List<String>>
+    private val valueParameters: Map<String, List<String>>
+    private val fixedParameters: Set<String>
+
+    init {
+        val foundParameters = "\\$\\{([^}]*)}".toRegex()
+            .findAll(format)
+            .map { it.groupValues[1] }
+            .toSet()
+
+        timeParameters = foundParameters
+            .filter { it.startsWith("time:") }
+            .associateWith { p ->
+                DateTimeFormatter
+                    .ofPattern(p.removePrefix("time:"))
+                    .withZone(UTC)
+            }
+
+        keyParameters = foundParameters
+            .filter { it.startsWith("key:") }
+            .associateWith { it.removePrefix("key:").split('.') }
+
+        valueParameters = foundParameters
+            .filter { it.startsWith("value:") }
+            .associateWith { it.removePrefix("value:").split('.') }
+
+        fixedParameters = buildSet {
+            addAll(foundParameters)
+            removeAll(timeParameters.keys)
+            removeAll(keyParameters.keys)
+            removeAll(valueParameters.keys)
+        }
+
+        val unsupportedParameters = fixedParameters.filterNot { it in supportedFixedParameters }
+        require(unsupportedParameters.isEmpty()) {
+            "Cannot use path format $format: unknown parameters $unsupportedParameters." +
+                " Legal parameter names are time formats (e.g., \${time:YYYYmmDD}" +
+                " or the following: $supportedFixedParameters"
+        }
+        require("topic" in fixedParameters) { "Path must include topic parameter." }
+        require("filename" in fixedParameters || ("extension" in fixedParameters && "attempt" in fixedParameters)) {
+            "Path must include filename parameter or extension and attempt parameters."
+        }
+    }
+
+    fun format(
+        topic: String,
+        key: GenericRecord,
+        value: GenericRecord,
+        time: Instant?,
+        attempt: Int,
+        extension: String,
+        computeTimeBin: (time: Instant?) -> String,
+    ): Path {
+        val attemptSuffix = if (attempt == 0) "" else "_$attempt"
+
+        val templatedParameters = mutableMapOf(
+            "projectId" to sanitizeId(key.get("projectId"), "unknown-project"),
+            "userId" to sanitizeId(key.get("userId"), "unknown-user"),
+            "sourceId" to sanitizeId(key.get("sourceId"), "unknown-source"),
+            "topic" to topic,
+            "filename" to computeTimeBin(time) + attemptSuffix + extension,
+            "attempt" to attemptSuffix,
+            "extension" to extension,
+        )
+
+        timeParameters.mapValuesTo(templatedParameters) { (_, formatter) ->
+            sanitizeId(time?.let { formatter.format(it) }, "unknown-time")
+        }
+        keyParameters.mapValuesTo(templatedParameters) { (_, index) ->
+            sanitizeId(key.lookup(index), "unknown-key")
+        }
+        valueParameters.mapValuesTo(templatedParameters) { (_, index) ->
+            sanitizeId(value.lookup(index), "unknown-value")
+        }
+
+        val path = templatedParameters.asSequence()
+            .fold(format) { p, (name, value) ->
+                p.replace("\${$name}", value)
+            }
+
+        return Paths.get(path)
+    }
+
+    companion object {
+        private val supportedFixedParameters = setOf(
+            "filename",
+            "topic",
+            "projectId",
+            "userId",
+            "sourceId",
+            "attempt",
+            "extension",
+        )
+
+        private fun GenericRecord.lookup(index: List<String>): Any? =
+            index.fold<String, Any?>(this) { r, item ->
+                r?.let { (it as? GenericRecord)?.get(item) }
+            }
+    }
+}

--- a/src/main/java/org/radarbase/output/path/PathFormatterPlugin.kt
+++ b/src/main/java/org/radarbase/output/path/PathFormatterPlugin.kt
@@ -1,0 +1,11 @@
+package org.radarbase.output.path
+
+import org.radarbase.output.Plugin
+
+abstract class PathFormatterPlugin : Plugin {
+    abstract val allowedFormats: String
+
+    abstract fun createLookupTable(
+        parameterNames: Set<String>
+    ): Map<String, PathFormatParameters.() -> String>
+}

--- a/src/main/java/org/radarbase/output/path/PathFormatterPlugin.kt
+++ b/src/main/java/org/radarbase/output/path/PathFormatterPlugin.kt
@@ -3,9 +3,47 @@ package org.radarbase.output.path
 import org.radarbase.output.Plugin
 
 abstract class PathFormatterPlugin : Plugin {
+    /**
+     * Prefix for parameter names covered by this plugin. If null, [extractParamContents] must be
+     * overridden to cover only supported parameters.
+     */
+    open val prefix: String? = null
+
+    /** Textual format of formats allowed to be represented. */
     abstract val allowedFormats: String
 
-    abstract fun createLookupTable(
-        parameterNames: Set<String>
-    ): Map<String, PathFormatParameters.() -> String>
+    /**
+     * Create a lookup table from parameter names to
+     * its value for a given record. Only parameter names supported by this plugin will be mapped.
+     * @throws IllegalArgumentException if any of the parameter contents are invalid.
+     */
+    fun createLookupTable(
+        parameterNames: Collection<String>
+    ): Map<String, PathFormatParameters.() -> String> = buildMap {
+        parameterNames.forEach { paramName ->
+            val paramContents = extractParamContents(paramName)
+            if (paramContents != null) {
+                put(paramName, lookup(paramContents))
+            }
+        }
+    }
+
+    /**
+     * Validate a parameter name and extract its contents to use in the lookup.
+     *
+     * @return name to use in the lookup or null if the parameter is not supported by this plugin
+     */
+    protected open fun extractParamContents(paramName: String): String? {
+        val prefixString = prefix?.let { "$it:" } ?: return null
+        if (!paramName.startsWith(prefixString)) return null
+        val parameterContents = paramName.removePrefix(prefixString).trim()
+        require(parameterContents.isNotEmpty()) { "Parameter contents of '$paramName' are empty" }
+        return parameterContents
+    }
+
+    /**
+     * Create a lookup function from a record to formatted value, based on parameter contents.
+     * @throws IllegalArgumentException if the parameter contents are invalid.
+     */
+    protected abstract fun lookup(parameterContents: String): PathFormatParameters.() -> String
 }

--- a/src/main/java/org/radarbase/output/path/RecordPathFactory.kt
+++ b/src/main/java/org/radarbase/output/path/RecordPathFactory.kt
@@ -20,6 +20,7 @@ import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.generic.GenericRecordBuilder
 import org.radarbase.output.Plugin
+import org.radarbase.output.config.TopicConfig
 import org.radarbase.output.util.TimeUtil
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
@@ -170,4 +171,6 @@ abstract class RecordPathFactory : Plugin {
         fun GenericRecord.getOrNull(fieldName: String): Any? = getFieldOrNull(fieldName)
             ?.let { get(it.pos()) }
     }
+
+    open fun addTopicConfiguration(topicConfig: Map<String, TopicConfig>) = Unit
 }

--- a/src/main/java/org/radarbase/output/path/RecordPathFactory.kt
+++ b/src/main/java/org/radarbase/output/path/RecordPathFactory.kt
@@ -19,6 +19,7 @@ package org.radarbase.output.path
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericRecord
 import org.apache.avro.generic.GenericRecordBuilder
+import org.radarbase.output.FileStoreFactory
 import org.radarbase.output.Plugin
 import org.radarbase.output.config.TopicConfig
 import org.radarbase.output.util.TimeUtil
@@ -32,6 +33,7 @@ import java.util.regex.Pattern
 abstract class RecordPathFactory : Plugin {
     lateinit var root: Path
     lateinit var extension: String
+    lateinit var fileStoreFactory: FileStoreFactory
 
     protected open var timeBinFormat: DateTimeFormatter = HOURLY_TIME_BIN_FORMAT
 

--- a/src/main/java/org/radarbase/output/path/TimePathFormatterPlugin.kt
+++ b/src/main/java/org/radarbase/output/path/TimePathFormatterPlugin.kt
@@ -1,0 +1,27 @@
+package org.radarbase.output.path
+
+import org.radarbase.output.path.RecordPathFactory.Companion.sanitizeId
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+class TimePathFormatterPlugin : PathFormatterPlugin() {
+    override val allowedFormats: String = "time:YYYY-mm-dd"
+
+    override fun createLookupTable(
+        parameterNames: Set<String>
+    ): Map<String, PathFormatParameters.() -> String> {
+        return parameterNames
+            .filter { it.startsWith("time:") }
+            .associateWith { p ->
+                val dateFormatter = DateTimeFormatter
+                    .ofPattern(p.removePrefix("time:"))
+                    .withZone(ZoneOffset.UTC)
+                return@associateWith {
+                    sanitizeId(
+                        time?.let { dateFormatter.format(it) },
+                        "unknown-time",
+                    )
+                }
+            }
+    }
+}

--- a/src/main/java/org/radarbase/output/path/TimePathFormatterPlugin.kt
+++ b/src/main/java/org/radarbase/output/path/TimePathFormatterPlugin.kt
@@ -5,23 +5,19 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 class TimePathFormatterPlugin : PathFormatterPlugin() {
+    override val prefix: String = "time"
+
     override val allowedFormats: String = "time:YYYY-mm-dd"
 
-    override fun createLookupTable(
-        parameterNames: Set<String>
-    ): Map<String, PathFormatParameters.() -> String> {
-        return parameterNames
-            .filter { it.startsWith("time:") }
-            .associateWith { p ->
-                val dateFormatter = DateTimeFormatter
-                    .ofPattern(p.removePrefix("time:"))
-                    .withZone(ZoneOffset.UTC)
-                return@associateWith {
-                    sanitizeId(
-                        time?.let { dateFormatter.format(it) },
-                        "unknown-time",
-                    )
-                }
-            }
+    override fun lookup(parameterContents: String): PathFormatParameters.() -> String {
+        val dateFormatter = DateTimeFormatter
+            .ofPattern(parameterContents)
+            .withZone(ZoneOffset.UTC)
+        return {
+            sanitizeId(
+                time?.let { dateFormatter.format(it) },
+                "unknown-time",
+            )
+        }
     }
 }

--- a/src/main/java/org/radarbase/output/path/ValuePathFormatterPlugin.kt
+++ b/src/main/java/org/radarbase/output/path/ValuePathFormatterPlugin.kt
@@ -1,0 +1,26 @@
+package org.radarbase.output.path
+
+import org.apache.avro.generic.GenericRecord
+import org.radarbase.output.path.RecordPathFactory.Companion.sanitizeId
+
+class ValuePathFormatterPlugin : PathFormatterPlugin() {
+    override val allowedFormats: String = "value:my.value.index"
+
+    override fun createLookupTable(
+        parameterNames: Set<String>
+    ): Map<String, (PathFormatParameters) -> String> = parameterNames
+        .filter { it.startsWith("value:") }
+        .associateWith { name ->
+            val index = name.removePrefix("value:").split('.')
+            return@associateWith { params ->
+                sanitizeId(params.value.lookup(index), "unknown-value")
+            }
+        }
+
+    companion object {
+        fun GenericRecord.lookup(index: List<String>): Any? =
+            index.fold<String, Any?>(this) { r, item ->
+                r?.let { (it as? GenericRecord)?.get(item) }
+            }
+    }
+}

--- a/src/main/java/org/radarbase/output/path/ValuePathFormatterPlugin.kt
+++ b/src/main/java/org/radarbase/output/path/ValuePathFormatterPlugin.kt
@@ -1,7 +1,9 @@
 package org.radarbase.output.path
 
+import org.apache.avro.AvroRuntimeException
 import org.apache.avro.generic.GenericRecord
 import org.radarbase.output.path.RecordPathFactory.Companion.sanitizeId
+import org.slf4j.LoggerFactory
 
 class ValuePathFormatterPlugin : PathFormatterPlugin() {
     override val prefix: String = "value"
@@ -18,8 +20,19 @@ class ValuePathFormatterPlugin : PathFormatterPlugin() {
 
     companion object {
         fun GenericRecord.lookup(index: List<String>): Any? =
-            index.fold<String, Any?>(this) { r, item ->
-                r?.let { (it as? GenericRecord)?.get(item) }
+            index.fold<String, Any?>(this) { record, item ->
+                record
+                    ?.let { it as? GenericRecord }
+                    ?.let {
+                        try {
+                            it.get(item)
+                        } catch (ex: AvroRuntimeException) {
+                            logger.warn("Unknown field {} in record using index {}", item, index)
+                            null
+                        }
+                    }
             }
+
+        private val logger = LoggerFactory.getLogger(ValuePathFormatterPlugin::class.java)
     }
 }

--- a/src/main/java/org/radarbase/output/path/ValuePathFormatterPlugin.kt
+++ b/src/main/java/org/radarbase/output/path/ValuePathFormatterPlugin.kt
@@ -4,18 +4,17 @@ import org.apache.avro.generic.GenericRecord
 import org.radarbase.output.path.RecordPathFactory.Companion.sanitizeId
 
 class ValuePathFormatterPlugin : PathFormatterPlugin() {
+    override val prefix: String = "value"
+
     override val allowedFormats: String = "value:my.value.index"
 
-    override fun createLookupTable(
-        parameterNames: Set<String>
-    ): Map<String, (PathFormatParameters) -> String> = parameterNames
-        .filter { it.startsWith("value:") }
-        .associateWith { name ->
-            val index = name.removePrefix("value:").split('.')
-            return@associateWith { params ->
-                sanitizeId(params.value.lookup(index), "unknown-value")
-            }
+    override fun lookup(parameterContents: String): PathFormatParameters.() -> String {
+        val index = parameterContents.split('.')
+        require(index.none { it.isBlank() }) { "Cannot format value record with index $parameterContents" }
+        return {
+            sanitizeId(value.lookup(index), "unknown-value")
         }
+    }
 
     companion object {
         fun GenericRecord.lookup(index: List<String>): Any? =

--- a/src/test/java/org/radarbase/output/OffsetRangeFileTest.kt
+++ b/src/test/java/org/radarbase/output/OffsetRangeFileTest.kt
@@ -16,6 +16,7 @@
 
 package org.radarbase.output
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -34,6 +35,7 @@ import java.nio.file.Path
 import java.time.Instant
 import kotlin.io.path.createFile
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class OffsetRangeFileTest {
     private lateinit var testFile: Path
     private lateinit var targetStorage: TargetStorage

--- a/src/test/java/org/radarbase/output/cleaner/TimestampFileCacheTest.kt
+++ b/src/test/java/org/radarbase/output/cleaner/TimestampFileCacheTest.kt
@@ -1,5 +1,6 @@
 package org.radarbase.output.cleaner
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
@@ -25,6 +26,7 @@ import java.io.FileNotFoundException
 import java.nio.file.Path
 import kotlin.io.path.bufferedWriter
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class TimestampFileCacheTest {
     private lateinit var record: GenericData.Record
     private var now: Double = 0.0

--- a/src/test/java/org/radarbase/output/data/CsvAvroConverterTest.kt
+++ b/src/test/java/org/radarbase/output/data/CsvAvroConverterTest.kt
@@ -17,6 +17,7 @@
 package org.radarbase.output.data
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.apache.avro.Schema.Parser
@@ -48,6 +49,7 @@ import kotlin.io.path.bufferedWriter
 import kotlin.io.path.inputStream
 import kotlin.io.path.outputStream
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class CsvAvroConverterTest {
     @Test
     @Throws(IOException::class)

--- a/src/test/java/org/radarbase/output/data/FileCacheStoreTest.kt
+++ b/src/test/java/org/radarbase/output/data/FileCacheStoreTest.kt
@@ -17,6 +17,7 @@
 package org.radarbase.output.data
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.apache.avro.SchemaBuilder
@@ -44,6 +45,7 @@ import java.nio.file.Path
 import java.time.Instant
 import kotlin.io.path.createDirectories
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class FileCacheStoreTest {
     private val lastModified = Instant.now()
 

--- a/src/test/java/org/radarbase/output/data/FileCacheTest.kt
+++ b/src/test/java/org/radarbase/output/data/FileCacheTest.kt
@@ -17,6 +17,7 @@
 package org.radarbase.output.data
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -50,6 +51,7 @@ import kotlin.io.path.inputStream
 /**
  * Created by joris on 03/07/2017.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class FileCacheTest {
     private lateinit var path: Path
     private lateinit var exampleRecord: Record

--- a/src/test/java/org/radarbase/output/data/JsonAvroConverterTest.kt
+++ b/src/test/java/org/radarbase/output/data/JsonAvroConverterTest.kt
@@ -18,6 +18,7 @@ package org.radarbase.output.data
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.apache.avro.Schema.Parser
 import org.apache.avro.generic.GenericDatumReader
@@ -37,6 +38,7 @@ import java.io.StringWriter
 import java.nio.file.Path
 import kotlin.io.path.bufferedWriter
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class JsonAvroConverterTest {
     @Test
     @Throws(IOException::class)

--- a/src/test/java/org/radarbase/output/path/FormattedPathFactoryTest.kt
+++ b/src/test/java/org/radarbase/output/path/FormattedPathFactoryTest.kt
@@ -1,12 +1,17 @@
 package org.radarbase.output.path
 
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.instanceOf
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.radarbase.output.path.FormattedPathFactory.Companion.toPathFormatterPlugin
 import org.radarcns.kafka.ObservationKey
 import org.radarcns.passive.phone.PhoneLight
 import java.nio.file.Paths
 import java.time.Instant
+import kotlin.reflect.jvm.jvmName
 
 internal class FormattedPathFactoryTest {
     @Test
@@ -98,5 +103,26 @@ internal class FormattedPathFactoryTest {
             mapOf("format" to format),
         )
         extension = ".csv.gz"
+    }
+
+    @Test
+    fun testNamedPluginCreate() {
+        assertThat("fixed".toPathFormatterPlugin(), instanceOf(FixedPathFormatterPlugin::class.java))
+        assertThat("time".toPathFormatterPlugin(), instanceOf(TimePathFormatterPlugin::class.java))
+        assertThat("key".toPathFormatterPlugin(), instanceOf(KeyPathFormatterPlugin::class.java))
+        assertThat("value".toPathFormatterPlugin(), instanceOf(ValuePathFormatterPlugin::class.java))
+    }
+
+    @Test
+    fun testBadPluginCreate() {
+        assertThat("unknown".toPathFormatterPlugin(), nullValue())
+    }
+
+    @Test
+    fun testClassPathPluginCreate() {
+        assertThat(
+            FixedPathFormatterPlugin::class.jvmName.toPathFormatterPlugin(),
+            instanceOf(FixedPathFormatterPlugin::class.java),
+        )
     }
 }

--- a/src/test/java/org/radarbase/output/path/PathFormatterTest.kt
+++ b/src/test/java/org/radarbase/output/path/PathFormatterTest.kt
@@ -1,0 +1,156 @@
+package org.radarbase.output.path
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.radarcns.kafka.ObservationKey
+import org.radarcns.monitor.application.ApplicationServerStatus
+import org.radarcns.monitor.application.ServerStatus
+import java.nio.file.Paths
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+internal class PathFormatterTest {
+    lateinit var params: PathFormatParameters
+
+    @BeforeEach
+    fun setupRecord() {
+        val defaultTimeFormat = DateTimeFormatter.ofPattern("YYYYMMdd_HH'00'")
+            .withZone(ZoneOffset.UTC)
+
+        params = PathFormatParameters(
+            topic = "my_topic",
+            key = ObservationKey(
+                "p",
+                "u",
+                "s",
+            ),
+            value = ApplicationServerStatus(
+                1.0,
+                ServerStatus.CONNECTED,
+                "1.1.1.1",
+            ),
+            time = Instant.ofEpochMilli(1000),
+            attempt = 0,
+            extension = ".csv",
+            computeTimeBin = { t -> if (t != null) defaultTimeFormat.format(t) else "unknown-time" }
+        )
+    }
+
+    @Test
+    fun testDefaultPath() {
+        val formatter = PathFormatter(
+            format = FormattedPathFactory.Companion.DEFAULT_FORMAT,
+            plugins = listOf(
+                FixedPathFormatterPlugin(),
+                TimePathFormatterPlugin(),
+                KeyPathFormatterPlugin(),
+                ValuePathFormatterPlugin(),
+            )
+        )
+        assertThat(formatter.format(params), equalTo(Paths.get("p/u/my_topic/19700101_0000.csv")))
+    }
+
+    @Test
+    fun testDefaultPathFewerPlugins() {
+        val formatter = PathFormatter(
+            format = FormattedPathFactory.Companion.DEFAULT_FORMAT,
+            plugins = listOf(
+                FixedPathFormatterPlugin(),
+            )
+        )
+        assertThat(formatter.format(params), equalTo(Paths.get("p/u/my_topic/19700101_0000.csv")))
+    }
+
+    @Test
+    fun testDefaultPathNoTime() {
+        val formatter = PathFormatter(
+            format = FormattedPathFactory.Companion.DEFAULT_FORMAT,
+            plugins = listOf(
+                FixedPathFormatterPlugin(),
+            )
+        )
+        assertThat(formatter.format(params.copy(time = null)), equalTo(Paths.get("p/u/my_topic/unknown-time.csv")))
+    }
+
+    @Test
+    fun testDefaultPathWrongPlugins() {
+        assertThrows(IllegalArgumentException::class.java) {
+            PathFormatter(
+                format = FormattedPathFactory.Companion.DEFAULT_FORMAT,
+                plugins = listOf(
+                    TimePathFormatterPlugin(),
+                    KeyPathFormatterPlugin(),
+                    ValuePathFormatterPlugin(),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testCorrectTimeFormatPlugins() {
+        val formatter = PathFormatter(
+            format = "\${topic}/\${time:YYYY-MM-dd_HH:mm:ss}\${attempt}\${extension}",
+            plugins = listOf(
+                FixedPathFormatterPlugin(),
+                TimePathFormatterPlugin(),
+            ),
+        )
+        assertThat(formatter.format(params), equalTo(Paths.get("my_topic/1970-01-01_000001.csv")))
+    }
+
+    @Test
+    fun testBadTimeFormatPlugins() {
+        assertThrows(IllegalArgumentException::class.java) {
+            PathFormatter(
+                format = "\${topic}/\${time:VVV}\${attempt}\${extension}",
+                plugins = listOf(
+                    FixedPathFormatterPlugin(),
+                    TimePathFormatterPlugin(),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun testCorrectKeyFormat() {
+        val formatter = PathFormatter(
+            format = "\${topic}/\${key:projectId}\${attempt}\${extension}",
+            plugins = listOf(
+                FixedPathFormatterPlugin(),
+                KeyPathFormatterPlugin(),
+            )
+        )
+
+        assertThat(formatter.format(params), equalTo(Paths.get("my_topic/p.csv")))
+    }
+
+    @Test
+    fun testUnknownKeyFormat() {
+        val formatter = PathFormatter(
+            format = "\${topic}/\${key:doesNotExist}\${attempt}\${extension}",
+            plugins = listOf(
+                FixedPathFormatterPlugin(),
+                KeyPathFormatterPlugin(),
+            )
+        )
+
+        assertThat(formatter.format(params), equalTo(Paths.get("my_topic/unknown-key.csv")))
+    }
+
+    @Test
+    fun testCorrectValueFormat() {
+        val formatter = PathFormatter(
+            format = "\${topic}/\${value:serverStatus}\${attempt}\${extension}",
+            plugins = listOf(
+                FixedPathFormatterPlugin(),
+                ValuePathFormatterPlugin(),
+            )
+        )
+
+        assertThat(formatter.format(params), equalTo(Paths.get("my_topic/CONNECTED.csv")))
+    }
+}


### PR DESCRIPTION
Allow changing the output path per topic based on simple data lookups. This is particularly useful if we add a `questionnaire_response` topic, which would get multiple questionnaire types. Then the output folder can still be changed based on the name of the questionnaire even though all those questionnaires were originally put in the same topic.

`FormattedPathFactory` now has an plugin structure, where multiple variable parsers can be inserted via configuration. This can be used in the future for example for adding ManagementPortal properties to the file structure (e.g. externalId, project group or set of related projects).