### PR TITLE
release-3.0.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 env:
   REGISTRY: ghcr.io
   REPOSITORY: ${{ github.repository }}
-  DOCKER_IMAGE: radar-output-restructure
+  IMAGE_NAME: radar-output-restructure
 
 jobs:
   upload:


### PR DESCRIPTION
The release action that uploads artifacts to maven central of the previous release was broken. This release tries to fix the release.