### PR TITLE
release-3.0.4-update

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 @Suppress("ConstPropertyName")
 object Versions {
-    const val project = "3.0.5"
+    const val project = "3.0.4"
 
     const val java = 17
     const val dockerCompose = "0.17.5"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,6 +1,6 @@
 @Suppress("ConstPropertyName")
 object Versions {
-    const val project = "3.0.3"
+    const val project = "3.0.5"
 
     const val java = 17
     const val dockerCompose = "0.17.5"


### PR DESCRIPTION
The release action that uploads artifacts to maven central of the previous release was broken. This release tries to fix the release.