### PR TITLE
Add configuration of Redis connection timeout duration 

### DIFF
--- a/src/main/java/org/radarbase/output/Application.kt
+++ b/src/main/java/org/radarbase/output/Application.kt
@@ -77,7 +77,9 @@ class Application(
     override val targetStorage: TargetStorage =
         TargetStorageFactory(config.target).createTargetStorage()
 
-    override val redisHolder: RedisHolder = RedisHolder(JedisPool(config.redis.uri))
+    override val redisHolder: RedisHolder = RedisHolder(
+        JedisPool(config.redis.uri, config.redis.timeoutMs)
+    )
     override val remoteLockManager: RemoteLockManager = RedisRemoteLockManager(
         redisHolder,
         config.redis.lockPrefix,

--- a/src/main/java/org/radarbase/output/config/RedisConfig.kt
+++ b/src/main/java/org/radarbase/output/config/RedisConfig.kt
@@ -15,7 +15,13 @@ data class RedisConfig(
      * Prefix to use for creating a lock of a topic.
      */
     val lockPrefix: String = "radar-output/lock",
+    /**
+     * Timeout in milliseconds for Redis operations.
+     */
+    val timeoutMs: Int = 5000
 ) {
     fun withEnv(): RedisConfig = this
         .copyEnv("REDIS_URI") { copy(uri = URI.create(it)) }
+        .copyEnv("REDIS_TIMEOUT_MS") { copy(timeoutMs = it.toInt()) }
+        .copyEnv("REDIS_LOCK_PREFIX") { copy(lockPrefix = it) }
 }


### PR DESCRIPTION
# Background
Output-restructure stores last processed offsets for each Kafka topic in Redis. The default timeout for the Redis connection is 2 seconds.

# Problem
When a lot of data is ingested for a specific topic the value of the key-value pair stored in Redis is too large to be retrieved in 2 seconds. This results in a timeout error and prevents _output-restructure_ to continue work.

# Solution
This PR will externalize the configuration of the Redis connection timeout duration to the config file so that larger values can be applied. 